### PR TITLE
fix missing fontconfig library when linking.

### DIFF
--- a/build/makefile/readme.md
+++ b/build/makefile/readme.md
@@ -14,7 +14,7 @@ NANAINC	= $(NANAPATH)/include
 NANALIB = $(NANAPATH)/build/bin
 
 INCS	= -I$(NANAINC)
-LIBS	= -L$(NANALIB) -lnana -lX11 -lpthread -lrt -lXft -lpng -lasound
+LIBS	= -L$(NANALIB) -lnana -lX11 -lpthread -lrt -lXft -lpng -lasound -lfontconfig
 
 LINKOBJ	= $(SOURCES:.cpp=.o)
 


### PR DESCRIPTION
```
eselnts1464> g++ hello.cc -isystem ../nana/include/ -L ../nana/build/bin/ -lnana -std=c++11 -lX11 -lpthread -lrt -lXft -lpng -lasound                                 # ~/w/cpp/nana/test_src
/bin/ld: ../nana/build/bin//libnana.a(platform_abstraction.o): undefined reference to symbol 'FcConfigAppFontAddFile'
/bin/ld: note: 'FcConfigAppFontAddFile' is defined in DSO /lib64/libfontconfig.so.1 so try adding it to the linker command line
/lib64/libfontconfig.so.1: could not read symbols: Invalid operation
collect2: error: ld returned 1 exit status
```